### PR TITLE
New feature: reusable Modal component incl. custom hooks

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from '@/providers/theme-provider'
 import { Header } from '@/components/common/header'
 import { Footer } from '@/components/common/footer'
 import { Analytics } from '@vercel/analytics/react'
+import { ModalProvider } from '@/lib/modalContext'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -45,17 +46,19 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <main
-            className={`flex min-h-screen flex-col ${inter.className}`}
-          >
-            <Header />
-            <div className="flex flex-1 justify-center w-full">
-              <div className="flex w-full max-w-[1280px] h-full">
-                {children}
+          <ModalProvider>
+            <main
+              className={`flex min-h-screen flex-col ${inter.className}`}
+            >
+              <Header />
+              <div className="flex flex-1 justify-center w-full">
+                <div className="flex w-full max-w-[1280px] h-full">
+                  {children}
+                </div>
               </div>
-            </div>
-            <Footer />
-          </main>
+              <Footer />
+            </main>
+          </ModalProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/common/authForm.tsx
+++ b/src/components/common/authForm.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { Button } from "../ui/button"
+import Modal from "../ui/modal"
+import Typography from "../ui/typography"
+
+interface ModalProps {
+    title: string
+  }
+
+export function AuthForm({ title }: ModalProps) {
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+
+  return(
+    <Modal>
+      <div className="bg-[hsl(var(--background))] w-full max-w-[300px] min-w-[250px] mx-auto p-8 px-5 border-2 border-[var(--foreground)]">
+        <Typography variant="h3">
+          {title}
+        </Typography>
+        <form className="w-full flex flex-col mt-4" onSubmit={handleSubmit}>
+          <label className="block opacity-75">Email</label>
+          <input className="text-black w-full mb-4" type="text" />
+          <label className="block opacity-75">Password</label>
+          <input className="text-black w-full mb-4" type="password" />
+          <Button color="ghost" size="tiny" className="mx-auto" onClick={(event) => { event.stopPropagation(); }}>
+            <Typography variant="p" className="text-black" >
+              Submit
+            </Typography>
+          </Button>
+        </form>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -12,6 +12,10 @@ import {
   DrawerTrigger
 } from '@/components/ui/drawer'
 import { MenuIcon, X } from 'lucide-react'
+import { useContext } from 'react'
+import { ModalContext } from '@/lib/modalContext'
+import Modal from '../ui/modal'
+import { AuthForm } from './authForm'
 
 interface SidebarProps
   extends React.HTMLAttributes<HTMLDivElement> {}
@@ -40,24 +44,40 @@ export function Header({ className }: SidebarProps) {
     </Link>
   )
 
+  const modalContext = useContext(ModalContext)
+
+  if (!modalContext) {
+    throw new Error('ModalContext is not available')
+  }
+
+  const { toggleModal, isActive, modalContent } = modalContext
+
+
   const getAuthButtons = () => (
     <div className="flex gap-3 items-center">
-      <Link
-        href="https://map.sistilli.dev/public/coding/SaaS+Boilerplate"
-        target="_blank"
+      <Button 
+        onClick={() => { toggleModal(<AuthForm title="Login" />); }} 
+        variant="outline" 
+        size="tiny"
       >
-        <Typography variant="p">Login</Typography>
-      </Link>
-      <Link
-        href="https://map.sistilli.dev/public/coding/SaaS+Boilerplate"
-        target="_blank"
+        <Typography 
+          variant="p"
+        >
+          Login
+        </Typography>
+      </Button>
+      <Button 
+        onClick={() => { toggleModal(<AuthForm title="Sign Up" />); }} 
+        color="ghost" 
+        size="tiny"
       >
-        <Button size="tiny" color="ghost">
-          <Typography variant="p" className="text-black">
-            Sign Up
-          </Typography>
-        </Button>
-      </Link>
+        <Typography 
+          variant="p" 
+          className="text-black"
+        >
+          Sign Up
+        </Typography>
+      </Button>
     </div>
   )
 
@@ -88,7 +108,8 @@ export function Header({ className }: SidebarProps) {
     )
   }
 
-  return (
+  return ( 
+    <>
     <div
       className={cn(
         `flex md:h-12 h-14 items-center justify-center w-full
@@ -134,5 +155,7 @@ export function Header({ className }: SidebarProps) {
         </div>
       </div>
     </div>
+    {isActive && <Modal>{modalContent}</Modal>}
+    </>
   )
 }

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import React, { useContext, useRef } from 'react'
+import { ModalContext } from '@/lib/modalContext'
+import { X } from 'lucide-react'
+import { useBodyScrollLock } from '@/lib/customHooks/useBodyScrollLock'
+import useClickOutside from '@/lib/customHooks/useClickOutside'
+
+interface ModalProps {
+  children: React.ReactNode
+}
+
+export default function Modal({ children }: ModalProps): React.ReactElement | null {
+
+  const context = useContext(ModalContext)
+
+  if (!context) {
+    return null
+  }
+
+  const { isActive, toggleModal } = context
+
+
+  // avoid scroll on body when Modal is open
+  useBodyScrollLock(isActive)
+
+
+  // apply the click outside detection and close modal when clicked outside
+  const containerRef = useRef<HTMLDivElement>(null)
+  const childRef = useRef<HTMLDivElement>(null)
+
+  useClickOutside({ containerRef, childRef, isActive, toggle: () => { toggleModal(null); } })
+
+
+  // toggle between classes
+  const modalClassName = isActive
+    ? 'fixed inset-0 h-screen w-full bg-black bg-opacity-30 backdrop-blur-md z-50 flex items-center justify-center'
+    : 'hidden'
+
+  return (
+    <div ref={containerRef} className={modalClassName}>
+      <X size={40} onClick={() => { toggleModal(null); }} className='absolute top-8 right-8 cursor-pointer' />
+      <div ref={childRef}>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/customHooks/useBodyScrollLock.ts
+++ b/src/lib/customHooks/useBodyScrollLock.ts
@@ -1,0 +1,15 @@
+import { useLayoutEffect } from 'react'
+
+export function useBodyScrollLock(active: boolean): void {
+  useLayoutEffect(() => {
+    const originalStyle = window.getComputedStyle(document.body).overflow
+
+    if (active) {
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      document.body.style.overflow = originalStyle
+    }
+  }, [active])
+}

--- a/src/lib/customHooks/useClickOutSide.ts
+++ b/src/lib/customHooks/useClickOutSide.ts
@@ -1,0 +1,35 @@
+import { useEffect, type RefObject } from "react"
+
+interface UseClickOutsideProps {
+  containerRef: RefObject<HTMLElement>
+  childRef: RefObject<HTMLElement>
+  isActive: boolean
+  toggle: () => void
+}
+
+const useClickOutside = ({ containerRef, childRef, isActive, toggle }: UseClickOutsideProps) => {
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      containerRef.current &&
+      childRef.current &&
+      !childRef.current.contains(event.target as Node)
+    ) {
+      toggle()
+      event.stopPropagation()
+    }
+  };
+
+  useEffect(() => {
+    if (isActive) {
+      document.addEventListener("mousedown", handleClickOutside)
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+    };
+  }, [isActive, containerRef, childRef, toggle])
+};
+
+export default useClickOutside

--- a/src/lib/modalContext.tsx
+++ b/src/lib/modalContext.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import React, { createContext, useState, type ReactNode, type ReactElement } from 'react'
+
+// Define the shape of the context
+interface ModalContextType {
+  isActive: boolean
+  modalContent: ReactElement | null // Explicitly allow null
+  toggleModal: (content?: ReactElement | null) => void // Allow passing null to close the modal
+}
+
+// Initialize the context
+export const ModalContext = createContext<ModalContextType | null>(null);
+
+interface ModalProviderProps {
+  children: ReactNode
+}
+
+export function ModalProvider({ children }: ModalProviderProps) {
+  const [isActive, setIsActive] = useState<boolean>(false);
+  const [modalContent, setModalContent] = useState<ReactElement | null>(null)
+
+  // Toggle the modal state and set the dynamic content
+  const toggleModal = (content?: ReactElement | null) => {
+    setModalContent(content || null)
+    setIsActive(!isActive)
+  }
+
+  return (
+    <ModalContext.Provider value={{ isActive, modalContent, toggleModal }}>
+      {children}
+    </ModalContext.Provider>
+  )
+}


### PR DESCRIPTION
I added a reusable Modal component. Recently I have seen the trend, especially in SAAS start ups, that login forms don't have their own URL any longer, but rather are in a pop-up modal. The modal can be reused for other components as well, like fx.the "book a call" button. Also I implemented custom hooks to prevent body scrolling when the modal is open, and closing the modal when clicked outside child element, fx login form.